### PR TITLE
Explicitly add `systemd` provider

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,7 @@
 class nats::service {
   service{$nats::service_name:
     ensure => "running",
-    enable => true
+    enable => true,
+    provider => systemd,
   }
 }


### PR DESCRIPTION
This module only works on system where `systemd` is the default init system. On system where it is not the case (like ubuntu), the service can't be started